### PR TITLE
[#54] 장바구니 DELETE API 연결

### DIFF
--- a/src/api/cart.ts
+++ b/src/api/cart.ts
@@ -8,7 +8,7 @@ const cartGetAxios = async () => {
     const response = await axiosWithAccessToken.get('/api/carts');
     return response.data.data;
   } catch (err) {
-    alert('⚠️ 장바구니 에러');
+    console.error(err);
   }
 };
 
@@ -25,7 +25,7 @@ const cartPostToJudgment = async (roomData: PostRoomData[]) => {
 
 const cartDeleteItem = async (cartId: number) => {
   try {
-    const response = await axios.delete(`/api/carts/${cartId}`);
+    const response = await axiosWithAccessToken.delete(`/api/carts/${cartId}`);
     return response.data;
   } catch (err) {
     alert('⚠️ 장바구니 삭제 에러');

--- a/src/components/layout/cart/CartItem.tsx
+++ b/src/components/layout/cart/CartItem.tsx
@@ -1,19 +1,19 @@
+/* eslint-disable no-alert */
 /* eslint-disable no-unneeded-ternary */
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import { useCallback, useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import { RiDeleteBin6Line } from 'react-icons/ri';
 import { ResponseCartData } from '../../../types';
-import { cartDeleteItem } from '../../../api/cart';
+import useCart from '../../../hooks/useCart';
 import theme from '../../../style/theme';
 import CartTotal from './CartTotal';
 
-interface CartDataProps {
-  carts: ResponseCartData[] | null;
-}
-
-const CartItem = (carts: CartDataProps) => {
-  const cartsData = carts?.carts;
+const CartItem = () => {
+  const {
+    cartQuery: { data: cartData },
+    deleteCartItemMutation,
+  } = useCart();
   const [checkedRoomList, setCheckedRoomList] = useState<ResponseCartData[]>(
     [],
   );
@@ -31,13 +31,13 @@ const CartItem = (carts: CartDataProps) => {
   );
 
   const handleAllCheckbox = useCallback(() => {
-    const allChecked = cartsData?.every((cart) =>
+    const allChecked = cartData.every((cart: ResponseCartData) =>
       checkedRoomList.includes(cart),
     );
     if (allChecked) {
       setCheckedRoomList([]);
     } else {
-      const allRoomIds = cartsData?.map((cart) => cart) || [];
+      const allRoomIds = cartData.map((cart: ResponseCartData) => cart) || [];
       setCheckedRoomList(allRoomIds);
     }
   }, [checkedRoomList]);
@@ -53,7 +53,7 @@ const CartItem = (carts: CartDataProps) => {
         `[${productName}]을 장바구니에서 제거하시겠습니까?`,
       );
       if (confirm) {
-        await cartDeleteItem(cartId);
+        await deleteCartItemMutation.mutate(cartId);
       }
     } catch (error) {
       console.log(error);
@@ -69,16 +69,18 @@ const CartItem = (carts: CartDataProps) => {
           css={AllCheckBox}
           onChange={handleAllCheckbox}
           checked={
-            cartsData &&
-            cartsData.every((cart) => checkedRoomList.includes(cart))
+            cartData &&
+            cartData.every((cart: ResponseCartData) =>
+              checkedRoomList.includes(cart),
+            )
               ? true
               : false
           }
         />
         <p css={AllSelect}>전체 선택</p>
       </label>
-      {cartsData &&
-        cartsData.map((cart) => (
+      {cartData &&
+        cartData.map((cart: ResponseCartData) => (
           <div css={Container} key={`${cart.cartId}_${cart.productName}`}>
             <label htmlFor="box" css={Label}>
               <input

--- a/src/components/layout/cart/CartNoItem.tsx
+++ b/src/components/layout/cart/CartNoItem.tsx
@@ -1,0 +1,52 @@
+/* eslint-disable react/button-has-type */
+import { css } from '@emotion/react';
+import { AiOutlineShoppingCart } from 'react-icons/ai';
+import { Link } from 'react-router-dom';
+import theme from '../../../style/theme';
+
+const CartNoItem = () => {
+  return (
+    <div css={Container}>
+      <AiOutlineShoppingCart css={CartIcon} />
+      <h1>장바구니에 담긴 상품이 없습니다.</h1>
+      <h3>원하는 상품을 담아보세요!</h3>
+      <Link to="/">
+        <button css={HomeButton}>숙소 둘러보기</button>
+      </Link>
+    </div>
+  );
+};
+
+export default CartNoItem;
+
+const Container = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+
+  height: calc(100vh - 5rem);
+`;
+
+const CartIcon = css`
+  width: 12.5rem;
+  height: 12.5rem;
+
+  color: ${theme.colors.blue500};
+`;
+
+const HomeButton = css`
+  margin-top: 1rem;
+  padding: 1rem 2.5rem;
+
+  border: 2px solid ${theme.colors.blue600};
+  border-radius: 0.5rem;
+
+  font-size: 1.2rem;
+  color: ${theme.colors.blue700};
+
+  &:hover {
+    font-weight: 700;
+  }
+`;

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -1,0 +1,22 @@
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { cartGetAxios, cartDeleteItem } from '../api/cart';
+
+const useCart = () => {
+  const queryClient = useQueryClient();
+  const cartQuery = useQuery('cart', cartGetAxios);
+
+  const deleteCartItemMutation = useMutation(
+    async (cartId: number) => {
+      await cartDeleteItem(cartId);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('cart');
+      },
+    },
+  );
+
+  return { cartQuery, deleteCartItemMutation };
+};
+
+export default useCart;

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -3,7 +3,9 @@ import { cartGetAxios, cartDeleteItem } from '../api/cart';
 
 const useCart = () => {
   const queryClient = useQueryClient();
-  const cartQuery = useQuery('cart', cartGetAxios);
+  const cartQuery = useQuery(['cart'], cartGetAxios, {
+    refetchOnWindowFocus: false,
+  });
 
   const deleteCartItemMutation = useMutation(
     async (cartId: number) => {

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -73,84 +73,6 @@ const handlers = [
     );
   }),
 
-  // 장바구니
-  // rest.get('/api/carts', async (_, res, ctx) => {
-  //   await sleep(500);
-  //   return res(
-  //     ctx.status(200),
-  //     ctx.json({
-  //       code: 200,
-  //       message: '장바구니 상품을 성공적으로 조회했습니다.',
-  //       data: [
-  //         {
-  //           cartId: 1,
-  //           productId: 1,
-  //           productName: '서산 오션 호텔',
-  //           images: '',
-  //           roomId: 1,
-  //           roomName: '디럭스룸',
-  //           price: 10000,
-  //           desc: '실내 흡연 금지',
-  //           standard: 2,
-  //           capacity: 2,
-  //           startDate: '2023-11-20',
-  //           endDate: '2023-11-21',
-  //           checkIn: '15:00',
-  //           checkOut: '11:00',
-  //         },
-  //         {
-  //           cartId: 2,
-  //           productId: 2,
-  //           productName: '남해 글래드810 풀빌라',
-  //           images: '',
-  //           roomId: 2,
-  //           roomName: '디럭스룸',
-  //           price: 20000,
-  //           desc: '실내 흡연 금지',
-  //           standard: 8,
-  //           capacity: 12,
-  //           startDate: '2023-12-24',
-  //           endDate: '2023-12-26',
-  //           checkIn: '15:00',
-  //           checkOut: '11:00',
-  //         },
-  //         {
-  //           cartId: 3,
-  //           productId: 3,
-  //           productName: '파크하얏트 부산',
-  //           images: '',
-  //           roomId: 3,
-  //           roomName: '디럭스 킹 요트 경기장 뷰',
-  //           price: 30000,
-  //           desc: '실내 취식 금지',
-  //           standard: 2,
-  //           capacity: 3,
-  //           startDate: '2024-01-01',
-  //           endDate: '2023-01-21',
-  //           checkIn: '15:00',
-  //           checkOut: '11:00',
-  //         },
-  //         {
-  //           cartId: 4,
-  //           productId: 4,
-  //           productName: '파크하얏트 부산',
-  //           images: '',
-  //           roomId: 3,
-  //           roomName: '디럭스 킹 요트 경기장 뷰',
-  //           price: 30000,
-  //           desc: '실내 취식 금지',
-  //           standard: 2,
-  //           capacity: 3,
-  //           startDate: '2024-01-01',
-  //           endDate: '2023-01-21',
-  //           checkIn: '15:00',
-  //           checkOut: '11:00',
-  //         },
-  //       ],
-  //     }),
-  //   );
-  // }),
-
   // 장바구니에서 주문하기 전 품절 여부 판단을 위한 post
   rest.post('/api/reservations/preoccupy', async (req, res, ctx) => {
     console.log('POST request to /api/reservations/preoccupy:', req.body);
@@ -178,19 +100,6 @@ const handlers = [
             ],
           },
         ],
-      }),
-    );
-  }),
-
-  // 장바구니 삭제
-  rest.delete('/api/carts/:cartId', async (req, res, ctx) => {
-    const { cartId } = req.params;
-    await sleep(500);
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 201,
-        message: `${cartId}: 삭제 완료`,
       }),
     );
   }),

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,25 +1,14 @@
 /* eslint-disable import/no-cycle */
-import { useEffect, useState } from 'react';
-import { ResponseCartData } from '../types';
-import { cartGetAxios } from '../api/cart';
+import useCart from '../hooks/useCart';
 import CartItem from '../components/layout/cart/CartItem';
+import CartNoItem from '../components/layout/cart/CartNoItem';
 
 const Cart = () => {
-  const [carts, setCarts] = useState<ResponseCartData[] | null>(null);
+  const {
+    cartQuery: { data: cartData },
+  } = useCart();
 
-  useEffect(() => {
-    const cartData = async () => {
-      try {
-        const data = await cartGetAxios();
-        setCarts(data);
-      } catch (error) {
-        console.error('장바구니 error: ', error);
-      }
-    };
-    cartData();
-  }, []);
-
-  return <CartItem carts={carts} />;
+  return cartData.length === 0 ? <CartNoItem /> : <CartItem />;
 };
 
 export default Cart;

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -8,7 +8,7 @@ const Cart = () => {
     cartQuery: { data: cartData },
   } = useCart();
 
-  return cartData.length === 0 ? <CartNoItem /> : <CartItem />;
+  return !cartData || cartData.length === 0 ? <CartNoItem /> : <CartItem />;
 };
 
 export default Cart;

--- a/src/style/globalStyles.ts
+++ b/src/style/globalStyles.ts
@@ -47,6 +47,7 @@ const globalStyles = css`
   button {
     border: 0;
     background: transparent;
+    cursor: pointer;
   }
 
   @font-face {


### PR DESCRIPTION
<!-- PR 제목 작성 양식 : [#이슈번호] 이슈 제목 PR -->

## 관련 이슈
close #54 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## Description
-  장바구니 DELETE
     - 실제 API 연결
     - 아이템 삭제시 UI에 즉시 반영
          - 장바구니에 아무것도 담겨있지 않을 때 UI 디자인
          
     - 리액트 쿼리를 사용하여 장바구니 관련 API hook화

- `globalStyles.ts` : button에 `cursor: pointer` 지정해두어서 따로 선언하지 않아도 적용될겁니다! 
<!-- 작업 내용을 적어주세요. -->
<!-- 강조할 부분은 볼드체로 작성해 주세요. -->

## 스크린샷(optional)
- 장바구니에 담긴 상품이 없을때
![image](https://github.com/Shimpyo-House/Shimpyo_FE/assets/83440978/c66c782d-dedb-4ce6-a63b-e659dc78da49)


- 장바구니 삭제
https://github.com/Shimpyo-House/Shimpyo_FE/assets/83440978/9a8bfc8e-fd73-48db-9a62-f583cd64638a


<!-- PR 결과를 첨부해주세요. -->




## 유의할 점 및 ETC (optional)
- 확인해보시고 코멘트 남겨주세요 🤗⭐
<!-- 팀원이 유의해야할 변경 사항이나 로직 및 기타 사항이 생겼다면 적어주세요. -->
