### PR TITLE
[#105] 상세페이지에서 장바구니에 물품 추가시 헤더 수량 변경

### DIFF
--- a/src/api/cart.ts
+++ b/src/api/cart.ts
@@ -1,17 +1,25 @@
-/* eslint-disable import/no-extraneous-dependencies */
-/* eslint-disable no-alert */
 /* eslint-disable consistent-return */
 import { axiosWithAccessToken } from '../Axios';
-import { RoomData } from '../types';
+import { RoomData, PostRoomToCart } from '../types';
 import { getCookie } from '../components/layout/auth/auth.utils';
 
+const accessToken = getCookie('accessToken');
+
 const cartGetAxios = async () => {
-  const accessToken = getCookie('accessToken');
   try {
     if (accessToken) {
       const response = await axiosWithAccessToken.get('/api/carts');
       return response.data.data;
     }
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+const cartPostAxios = async (requestData: PostRoomToCart) => {
+  try {
+    const response = await axiosWithAccessToken.post('/api/carts', requestData);
+    return response.data.data;
   } catch (err) {
     console.error(err);
   }
@@ -38,4 +46,4 @@ const cartDeleteItem = async (cartId: number) => {
   }
 };
 
-export { cartGetAxios, cartPostToJudgment, cartDeleteItem };
+export { cartGetAxios, cartPostAxios, cartPostToJudgment, cartDeleteItem };

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -13,7 +13,7 @@ const Header = () => {
   useGetUserData();
   const user = useRecoilValue(userAtom);
   const {
-    cartQuery: { data: cartData },
+    cartGetQuery: { data: cartData },
   } = useCart();
 
   return (

--- a/src/components/layout/cart/CartItem.tsx
+++ b/src/components/layout/cart/CartItem.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable prefer-template */
 /* eslint-disable @typescript-eslint/indent */
 /* eslint-disable no-unneeded-ternary */
@@ -19,7 +18,7 @@ import CartTotal from './CartTotal';
 
 const CartItem = () => {
   const {
-    cartQuery: { data: cartData },
+    cartGetQuery: { data: cartData },
     deleteCartItemMutation,
   } = useCart();
   const [checkedRoomList, setCheckedRoomList] = useRecoilState(

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -1,11 +1,23 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query';
-import { cartGetAxios, cartDeleteItem } from '../api/cart';
+import { cartGetAxios, cartDeleteItem, cartPostAxios } from '../api/cart';
+import { PostRoomToCart } from '../types';
 
 const useCart = () => {
   const queryClient = useQueryClient();
-  const cartQuery = useQuery(['cart'], cartGetAxios, {
+  const cartGetQuery = useQuery(['cart'], cartGetAxios, {
     refetchOnWindowFocus: false,
   });
+
+  const cartPostMutation = useMutation(
+    async (requestData: PostRoomToCart) => {
+      await cartPostAxios(requestData);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('cart');
+      },
+    },
+  );
 
   const deleteCartItemMutation = useMutation(
     async (cartId: number) => {
@@ -18,7 +30,7 @@ const useCart = () => {
     },
   );
 
-  return { cartQuery, deleteCartItemMutation };
+  return { cartGetQuery, cartPostMutation, deleteCartItemMutation };
 };
 
 export default useCart;

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -4,7 +4,7 @@ import CartNoItem from '../components/layout/cart/CartNoItem';
 
 const Cart = () => {
   const {
-    cartQuery: { data: cartData },
+    cartGetQuery: { data: cartData },
   } = useCart();
 
   return !cartData || cartData.length === 0 ? <CartNoItem /> : <CartItem />;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,19 @@ export type Room = {
   reserved: boolean;
 };
 
+export type PostRoomToCart = {
+  roomId: number;
+  roomName: string;
+  price: number;
+  desc: string;
+  standard: number;
+  checkIn: string;
+  checkOut: string;
+  reserved: boolean;
+  startDate: string;
+  endDate: string;
+};
+
 export type RequestProductDetail = {
   productId: string;
   category: string;


### PR DESCRIPTION
<!-- PR 제목 작성 양식 : [#이슈번호] 이슈 제목 PR -->

## 관련 이슈
close #105 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## Description
- `ProductsDetail.tsx`에서 장바구니에 물품 추가시 헤더 수량 변경
- 장바구니 관련 api 분리 후 적용 
     - `ProductsDetail.tsx` 수정 : api 분리 후 적용시켜뒀습니다
<!-- 작업 내용을 적어주세요. -->
<!-- 강조할 부분은 볼드체로 작성해 주세요. -->

## 스크린샷(optional)
- 장바구니에 물품 추가시 헤더 수량 변경
![1207](https://github.com/Shimpyo-House/Shimpyo_FE/assets/83440978/dbcca3e1-f615-4b27-8329-36ff5576b0d0)



<!-- PR 결과를 첨부해주세요. -->

## 유의할 점 및 ETC (optional)
- `ProductsDetail.tsx` 부분이 수정이 좀 되어서 사용하시는 분 확인 한번 해주세요~!

<!-- 팀원이 유의해야할 변경 사항이나 로직 및 기타 사항이 생겼다면 적어주세요. -->
