### PR TITLE
[#116] 상세 페이지 - 룸 상세 정보 모달 추가

### DIFF
--- a/src/components/layout/productsDetail/ProductsDetail.tsx
+++ b/src/components/layout/productsDetail/ProductsDetail.tsx
@@ -1,4 +1,5 @@
-/* eslint-disable consistent-return */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable @typescript-eslint/indent */
 /* eslint-disable react/jsx-no-useless-fragment */
 /* eslint-disable @typescript-eslint/no-shadow */
@@ -31,6 +32,7 @@ import ImageSlider from './ImageSlider';
 import useCart from '../../../hooks/useCart';
 import { cartPostToJudgment } from '../../../api/cart';
 import { useLocationData } from '../../../api/productsList';
+import RoomOptionModal from './RoomOptionModal';
 
 const ProductsDetail = () => {
   const navigate = useNavigate();
@@ -61,6 +63,14 @@ const ProductsDetail = () => {
   );
 
   const setLoading = useSetRecoilState(loadingAtom);
+
+  const [roomOptionModalOpen, setRoomOptionModalOpen] = useState(false);
+  const [selectedRoomCode, setSelectedRoomCode] = useState<number | null>(null);
+
+  const handleRoomOpen = (roomCode: number) => {
+    setSelectedRoomCode(roomCode);
+    setRoomOptionModalOpen(true);
+  };
 
   // 선택한 숙박일 수 부모 컴포넌트 상태에 업데이트
   const handleSetNights = (selectedNights: SetStateAction<number>) => {
@@ -94,8 +104,6 @@ const ProductsDetail = () => {
           `/api/products/${productId}?startDate=${startDate}&endDate=${endDate}`,
         );
         setProductDetail(response.data.data);
-
-        console.log(response.data.data);
       } catch (error) {
         console.error('Error fetching product detail:', error);
       } finally {
@@ -247,10 +255,7 @@ const ProductsDetail = () => {
   const handleShowNearbyClick = async () => {
     try {
       const location = productDetail.address.address.split(' ')[0];
-      console.log(location);
-
       const fetchData = await useLocationData(location);
-
       console.log('주변 숙소 데이터:', fetchData);
     } catch (error) {
       console.error('주변 숙소 데이터 불러오기 에러:', error);
@@ -320,7 +325,7 @@ const ProductsDetail = () => {
                 css={RoomImg}
                 style={{ backgroundImage: `url('${productDetail.images[0]}')` }}
               />
-              <div css={RoomInfo}>
+              <div css={RoomInfo} onClick={() => handleRoomOpen(room.roomCode)}>
                 <div css={RoomName}>{room.roomName}</div>
                 <div
                   css={RoomCount}
@@ -395,6 +400,12 @@ const ProductsDetail = () => {
             </div>
           ))}
         </div>
+        <RoomOptionModal
+          openModal={roomOptionModalOpen}
+          closeModal={() => setRoomOptionModalOpen(false)}
+          productDetail={productDetail}
+          selectedRoomCode={selectedRoomCode}
+        />
         {modalIsOpen && (
           <div
             className="modal-container"
@@ -590,6 +601,7 @@ const RoomInfo = css`
   padding: 0.625rem;
   margin-left: 1.25rem;
   font-weight: bold;
+  cursor: pointer;
 `;
 
 const RoomName = css`

--- a/src/components/layout/productsDetail/RoomOptionModal.tsx
+++ b/src/components/layout/productsDetail/RoomOptionModal.tsx
@@ -1,0 +1,128 @@
+import { css } from '@emotion/react';
+import Modal from 'react-modal';
+import { IoClose } from 'react-icons/io5';
+import { RequestProductDetail } from '../../../types';
+
+Modal.setAppElement('#root');
+
+interface ModalProps {
+  openModal: boolean;
+  closeModal: () => void;
+  productDetail: RequestProductDetail;
+  selectedRoomCode: number | null;
+}
+
+interface RoomOptionResponse {
+  bathFacility: boolean;
+  bath: boolean;
+  homeTheater: boolean;
+  airCondition: boolean;
+  tv: boolean;
+  pc: boolean;
+  cable: boolean;
+  internet: boolean;
+  refrigerator: boolean;
+  toiletries: boolean;
+  sofa: boolean;
+  cooking: boolean;
+  table: boolean;
+  hairDryer: boolean;
+}
+
+const RoomOptionModal = ({
+  openModal,
+  closeModal,
+  productDetail,
+  selectedRoomCode,
+}: ModalProps) => {
+  const selectedRoom = productDetail.rooms.find(
+    (room) => room.roomCode === selectedRoomCode,
+  );
+  const serviceKey = (key: string) => {
+    const keyKoreanName: Record<string, string> = {
+      bathFacility: '샤워 시설',
+      bath: '욕조',
+      homeTheater: 'OTT 플랫폼',
+      airCondition: '에어컨',
+      tv: 'TV',
+      pc: 'PC',
+      cable: '케이블',
+      internet: '무료 와이파이',
+      refrigerator: '냉장고',
+      toiletries: '화장실',
+      sofa: '쇼파',
+      cooking: '요리 시설',
+      table: '식탁',
+      hairDryer: '헤어 드라이기',
+    };
+
+    return keyKoreanName[key];
+  };
+  const serviceValue = (value: RoomOptionResponse) => (value ? '✅' : '❌');
+  return (
+    <Modal isOpen={openModal} style={ModalStyles}>
+      <IoClose css={CloseButton} onClick={closeModal} />
+      {selectedRoom && (
+        <div css={RoomInfoContainer}>
+          <h2 css={RoomInfoTitle}>객실 시설 및 서비스</h2>
+          {Object.entries(selectedRoom.roomOptionResponse).map(
+            ([key, value]) => (
+              <span key={key}>
+                {`${serviceValue(value)} ${serviceKey(key)} `}
+                <br />
+              </span>
+            ),
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default RoomOptionModal;
+
+const ModalStyles: ReactModal.Styles = {
+  overlay: {
+    backgroundColor: ' rgba(0, 0, 0, 0.05)',
+    width: '100%',
+    height: '100vh',
+    zIndex: '90000',
+    position: 'fixed',
+    top: '0',
+    left: '0',
+  },
+  content: {
+    width: '40rem',
+    height: '40rem',
+    zIndex: '150',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    borderRadius: '10px',
+    boxShadow: '2px 2px 2px rgba(0, 0, 0, 0.1)',
+    backgroundColor: 'white',
+    justifyContent: 'center',
+    overflow: 'auto',
+  },
+};
+
+const CloseButton = css`
+  width: 2rem;
+  height: 2rem;
+
+  margin-left: 94%;
+
+  cursor: pointer;
+`;
+
+const RoomInfoContainer = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+`;
+
+const RoomInfoTitle = css`
+  margin-bottom: 1.5rem;
+`;


### PR DESCRIPTION
<!-- PR 제목 작성 양식 : [#이슈번호] 이슈 제목 PR -->

## 관련 이슈
close #116 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## Description
- 상세페이지에서 room을 클릭하면 그에 해당하는 룸 상세 정보가 나타납니다.

- `RoomOptionModal.tsx`에 존재하는 타입은 추후에 분리 예정 (리팩토링)

<!-- 작업 내용을 적어주세요. -->
<!-- 강조할 부분은 볼드체로 작성해 주세요. -->

## 스크린샷(optional)
- 클릭시 뜨는 모달창
![image](https://github.com/Shimpyo-House/Shimpyo_FE/assets/83440978/1d347c03-a73f-44c5-ae23-c502f43e8201)


<!-- PR 결과를 첨부해주세요. -->

## 유의할 점 및 ETC (optional)
-  `ProductsDetail.tsx` 에 코드 변화가 많으니 사용하시는 분들 꼭 확인 부탁드릴게요!
     - `ProductsDetail.tsx`에 주석 처리 한 부분은 모두 삭제해주세요! (혹시 몰라서 삭제 안했습니다 ㅎㅎ)
- 디자인이 매우매우.. 구려서 이것도 추후에 더 수정할 예정입니다.. 많관부 🥲🥲
<!-- 팀원이 유의해야할 변경 사항이나 로직 및 기타 사항이 생겼다면 적어주세요. -->
